### PR TITLE
add support for subparsers

### DIFF
--- a/selfcompletion/__init__.py
+++ b/selfcompletion/__init__.py
@@ -28,7 +28,7 @@ class _StoreAction(argparse._StoreAction):
         return vars(self) == vars(other)
 
 class SelfCompletingArgumentParser(argparse.ArgumentParser):
-    def __init__(self, add_completion=True, parser_class=None, *args, **kw):
+    def __init__(self, add_completion=True, *args, **kw):
         super(SelfCompletingArgumentParser, self).__init__(*args, **kw)
         if add_completion:
             completion_action = _CompletionAction(['--_completion'])

--- a/selfcompletion/__init__.py
+++ b/selfcompletion/__init__.py
@@ -28,10 +28,11 @@ class _StoreAction(argparse._StoreAction):
         return vars(self) == vars(other)
 
 class SelfCompletingArgumentParser(argparse.ArgumentParser):
-    def __init__(self, *args, **kw):
+    def __init__(self, add_completion=True, parser_class=None, *args, **kw):
         super(SelfCompletingArgumentParser, self).__init__(*args, **kw)
-        completion_action = _CompletionAction(['--_completion'])
-        self._add_action(completion_action)
+        if add_completion:
+            completion_action = _CompletionAction(['--_completion'])
+            self._add_action(completion_action)
 
     def get_valid_next_words(self, words):
         valid_words = []
@@ -65,10 +66,19 @@ class SelfCompletingArgumentParser(argparse.ArgumentParser):
                         # consume first positional
                         positionals = positionals[1:]
                 for action in positionals:
+                    choices = action.choices
+                    if hasattr(action, 'add_parser'):
+                        last = None
+                        for word in reversed(words):
+                            if len(word) and not word.startswith('-'):
+                                last = word
+                                break
+                        if last in choices:
+                            return choices[last].get_valid_next_words(words)
                     if action.type is not None:
                         types.append(action.type)
-                    if action.choices:
-                        valid_words.extend([c+' ' for c in action.choices])
+                    if choices:
+                        valid_words.extend([c+' ' for c in choices])
                     if action.nargs in (None, 1):
                         break
         if int in types:

--- a/selfcompletion/test/test_completing.py
+++ b/selfcompletion/test/test_completing.py
@@ -230,9 +230,16 @@ class TestHandlesSubParsers(unittest.TestCase):
     def setUp(self):
         self.parser = selfcompletion.SelfCompletingArgumentParser()
         self.subparsers = self.parser.add_subparsers(help='commands')
-        self.subparser = self.subparsers.add_parser('foo',
-                parser_class=selfcompletion.SelfCompletingArgumentParser)
+        self.subparser = self.subparsers.add_parser('foo')
         self.subparser.add_argument('--something')
+
+    def test_command(self):
+        word_options = self.parser.get_valid_next_words([''])
+        self.assertItemsEqual(word_options, [
+                'foo ',
+                '-h ', '--help ',
+                '--_completion ', '-- ',
+            ])
 
     def test_sub_command(self):
         word_options = self.parser.get_valid_next_words(['cmd', 'foo', ''])

--- a/selfcompletion/test/test_completing.py
+++ b/selfcompletion/test/test_completing.py
@@ -226,3 +226,18 @@ class TestTakesOpt2Args(unittest.TestCase):
                 '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
             ])
 
+class TestHandlesSubParsers(unittest.TestCase):
+    def setUp(self):
+        self.parser = selfcompletion.SelfCompletingArgumentParser()
+        self.subparsers = self.parser.add_subparsers(help='commands')
+        self.subparser = self.subparsers.add_parser('foo',
+                parser_class=selfcompletion.SelfCompletingArgumentParser)
+        self.subparser.add_argument('--something')
+
+    def test_sub_command(self):
+        word_options = self.parser.get_valid_next_words(['cmd', 'foo', ''])
+        self.assertItemsEqual(word_options, [
+                '--something ',
+                '-h ', '--help ',
+                '--_completion ', '-- ',
+            ])


### PR DESCRIPTION
this change delegates `get_valid_next_words()` to a subparser where
appropriate. example usage:

```
from selfcompletion import SelfCompletingArgumentParser
parser = SelfCompletingArgumentParser()
subparsers = parser.add_subparsers()
subparser = subparsers.add_parser('foo',
        parser_class=SelfCompletingArgumentParser)
subparser.add_argument('--something')
```

unit test included.
